### PR TITLE
Architecture support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Permission to:
 
 Role Variables
 --------------
-A non-exhuastive list of available variables is listed below, along with their default vaules. For a list of variables available for the AdguardHome configuration file please see `templates/AdGuardHome-{{ adguardhome_template_version }}.yaml.j2`.
+A non-exhuastive list of available variables is listed below, along with their default vaules. For a list of variables available for the AdguardHome configuration file, please see `defaults/main.yml`.
 
     adguardhome_version: 0.107.36
 
@@ -43,6 +43,15 @@ The name of the service used to control the AdGuardHome process.
     adguardhome_config_dir: /etc/adguardhome
 
 Default folders created for AdguardHome binaries and data.
+
+    adguardhome_bin_file: "{{ adguardhome_bin_dir }}/AdGuardHome"
+    adguardhome_config_file: "{{ adguardhome_config_dir }}/AdGuardHome"
+
+Default file names for the AdguardHome binary and config file.
+
+    adguardhome_download_uri:
+
+Optional URI that will override the default AdGuardHome URL constructed by this role. The URI must point to a tarball that has the same structure as the official AdGuardHome release files. If it is a file location, the file must already exist on the remote machine. This is only necessary for custom/local builds or architectures this role does not yet properly detect.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,9 @@ adguardhome_daemon: adguardhome
 adguardhome_home_dir: /var/lib/adguardhome
 adguardhome_data_dir: "{{ adguardhome_home_dir }}"
 adguardhome_bin_dir: /usr/local/bin
+adguardhome_bin_file: "{{ adguardhome_bin_dir }}/AdGuardHome"
 adguardhome_config_dir: /etc/adguardhome
+adguardhome_config_file: "{{ adguardhome_config_dir }}/AdGuardHome.yaml"
 
 adguardhome_manage_config: true
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,7 +3,7 @@
 - name: Check config file for changes.
   ansible.builtin.template:
     src: AdGuardHome.yaml.j2
-    dest: "{{ adguardhome_config_dir }}/AdGuardHome.yaml"
+    dest: "{{ adguardhome_config_file }}"
     owner: "{{ adguardhome_user }}"
     group: "{{ adguardhome_group }}"
     mode: 0644
@@ -21,7 +21,7 @@
 - name: Copy config file.
   ansible.builtin.template:
     src: AdGuardHome.yaml.j2
-    dest: "{{ adguardhome_config_dir }}/AdGuardHome.yaml"
+    dest: "{{ adguardhome_config_file }}"
     owner: "{{ adguardhome_user }}"
     group: "{{ adguardhome_group }}"
     mode: 0644

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,7 +15,7 @@
 
 - name: Check if AdGuardHome is already installed.
   ansible.builtin.command:
-    cmd: "{{ adguardhome_bin_dir }}/AdGuardHome --version"
+    cmd: "{{ adguardhome_bin_file }} --version"
   register: __adguardhome_version_result
   ignore_errors: true
   changed_when: false
@@ -23,7 +23,7 @@
 - name: Install AdGuardHome.
   ansible.builtin.unarchive:
     src: "https://github.com/AdguardTeam/AdGuardHome/releases/download/v{{ adguardhome_version }}/AdGuardHome_linux_amd64.tar.gz"  # yamllint disable-line rule:line-length
-    dest: /usr/local/bin/
+    dest: "{{ adguardhome_bin_dir }}"
     remote_src: true
     include:
       - ./AdGuardHome/AdGuardHome

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,7 +22,7 @@
 
 - name: Install AdGuardHome.
   ansible.builtin.unarchive:
-    src: "https://github.com/AdguardTeam/AdGuardHome/releases/download/v{{ adguardhome_version }}/AdGuardHome_linux_amd64.tar.gz"  # yamllint disable-line rule:line-length
+    src: "{{ adguardhome_download_uri | default(__adguardhome_download_url) }}"
     dest: "{{ adguardhome_bin_dir }}"
     remote_src: true
     include:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,5 @@
+---
+__architecture_map:
+  x86_64: amd64
+  i386: "386"
+  aarch64: arm64

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,5 @@
 ---
+__adguardhome_download_url: "https://github.com/AdguardTeam/AdGuardHome/releases/download/v{{ adguardhome_version }}/AdGuardHome_linux_{{ __architecture_map[ansible_architecture] }}.tar.gz"
 __architecture_map:
   x86_64: amd64
   i386: "386"


### PR DESCRIPTION
Detect the machines architecture and download the appropriate binary. This implementation also allows the user to override the download url for custom builds.