### PR TITLE
Update to AdGuard Home 0.107.52

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Installs AdGuardHome on Linux machines.
 
 Versioning Policy
 -----------------
-Each minor version of this role is designed to be compatible with the corresponding patch release of `AdGuardHome`. For example, version `107.51.x` is compatible with `AdGuardHome` version `0.107.51`. This is due to breaking changes introduced in the settings file and allows for bug fix releases in the role between updates.
+Each minor version of this role is designed to be compatible with the corresponding patch release of `AdGuardHome`. For example, version `107.52.x` is compatible with `AdGuardHome` version `0.107.52`. This is due to breaking changes introduced in the settings file and allows for bug fix releases in the role between updates.
 
 Install
 -------
 Using ansible galaxy
 
-`ansible-galaxy install bcook254.adguardhome>=107.51,<107.52`
+`ansible-galaxy install bcook254.adguardhome>=107.52,<107.53`
 
 Requirements
 ------------
@@ -24,7 +24,7 @@ Role Variables
 --------------
 A non-exhuastive list of available variables is listed below, along with their default vaules. For a list of variables available for the AdguardHome configuration file, please see `defaults/main.yml`.
 
-    adguardhome_version: 0.107.51
+    adguardhome_version: 0.107.52
 
 The version of AdGuardHome to be installed.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-adguardhome_version: 0.107.51
+adguardhome_version: 0.107.52
 adguardhome_user: adguardhome
 adguardhome_group: adguardhome
 adguardhome_daemon: adguardhome
@@ -139,6 +139,7 @@ adguardhome_log_localtime: 'false'
 adguardhome_log_max_backups: 0
 adguardhome_log_max_size: 100
 adguardhome_log_max_age: 3
+adguardhome_log_enabled: 'true'
 adguardhome_log_file: '""'
 adguardhome_verbose: 'false'
 adguardhome_os_group: '""'

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -14,7 +14,7 @@
       chdir: /usr/local/bin
     changed_when: false
     register: __adguardhome_version
-    failed_when: __adguardhome_version is not search('0.107.51')
+    failed_when: __adguardhome_version is not search('0.107.52')
 
   - name: Check if adguardhome.service is started
     ansible.builtin.service:

--- a/templates/AdGuardHome.yaml.j2
+++ b/templates/AdGuardHome.yaml.j2
@@ -352,6 +352,7 @@ clients:
 {% endfor %}
 {% endif %}
 log:
+  enabled: {{ adguardhome_log_enabled }}
   file: {{ adguardhome_log_file }}
   max_backups: {{ adguardhome_log_max_backups }}
   max_size: {{ adguardhome_log_max_size }}


### PR DESCRIPTION
Adds "log.enabled" setting, default 'true'