### PR TITLE
Fix variable name in AdGuardHome template

### DIFF
--- a/templates/AdGuardHome.yaml.j2
+++ b/templates/AdGuardHome.yaml.j2
@@ -40,7 +40,7 @@ dns:
  []
 {% else %}
 
-{% for address in ratelimit_whitelist %}
+{% for address in adguardhome_ratelimit_whitelist %}
     - {{ address }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
#56 

This pull request makes a small change to the `templates/AdGuardHome.yaml.j2` template, updating the variable used for the rate limit whitelist in the DNS configuration.

* Replaced usage of the `ratelimit_whitelist` variable with `adguardhome_ratelimit_whitelist` in the DNS configuration section of `templates/AdGuardHome.yaml.j2`.